### PR TITLE
fix `backdrop-image` typo

### DIFF
--- a/src/site/content/en/blog/backdrop-filter/index.md
+++ b/src/site/content/en/blog/backdrop-filter/index.md
@@ -84,7 +84,7 @@ You can combine filters for rich and clever effects, or use just one filter for 
 
 ## Feature detection and fallback
 
-As with many features of the modern web, you'll want to know whether the user's browser supports `backdrop-filter` before using it. Do this with `@supports()`. For performance reasons, fall back to an image instead of a polyfill when `backdrop-image` isn't supported. The example below shows this.
+As with many features of the modern web, you'll want to know whether the user's browser supports `backdrop-filter` before using it. Do this with `@supports()`. For performance reasons, fall back to an image instead of a polyfill when `backdrop-filter` isn't supported. The example below shows this.
 
 ```css
 @supports (backdrop-filter: none) {

--- a/src/site/content/es/blog/backdrop-filter/index.md
+++ b/src/site/content/es/blog/backdrop-filter/index.md
@@ -65,7 +65,7 @@ Puede combinar filtros para obtener efectos enriquecidos e inteligentes, o usar 
 
 ## Detección de funciones y plan B
 
-Al igual que con muchas funciones de la web moderna, querrá saber si el navegador del usuario admite `backdrop-filter` antes de usarlo. Hágalo con `@supports()`. Por motivos de rendimiento, recurra a una imagen en lugar de un polyfill cuando `backdrop-image` no sea compatible. El siguiente ejemplo lo ilustra.
+Al igual que con muchas funciones de la web moderna, querrá saber si el navegador del usuario admite `backdrop-filter` antes de usarlo. Hágalo con `@supports()`. Por motivos de rendimiento, recurra a una imagen en lugar de un polyfill cuando `backdrop-filter` no sea compatible. El siguiente ejemplo lo ilustra.
 
 ```css
 @supports (backdrop-filter: none) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Replaced the word `backdrop-image` with `backdrop-filter` on the content of this https://web.dev/backdrop-filter article
